### PR TITLE
Drop obsolete dependency on distribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ test_dependencies = [
   'coverage             >= 3.6',
   ]
 
-dependencies = [
-  'distribute           >= 0.6.24',
-  ]
+dependencies = []
 
 entrypoints = {
   # 'console_scripts': [


### PR DESCRIPTION
From https://pythonhosted.org/distribute/:

"""
Distribute is a deprecated fork of the Setuptools project.

Since the Setuptools 0.7 release, Setuptools and Distribute have merged and
Distribute is no longer being maintained. All ongoing effort should reference
the Setuptools project and the Setuptools documentation.
"""

Signed-off-by: Justin Lecher jlec@gentoo.org
